### PR TITLE
Resolves #40.

### DIFF
--- a/TestStack.FluentMvcTesting/ControllerResultTest/ControllerResultTest.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ControllerResultTest.cs
@@ -4,30 +4,30 @@ namespace TestStack.FluentMVCTesting
 {
     public partial class ControllerResultTest<T> where T : Controller
     {
-        private readonly T _controller;
-        private readonly string _actionName;
-        private readonly ActionResult _actionResult;
+        public T Controller { get; private set; }
+        public string ActionName { get; private set; }
+        public ActionResult ActionResult { get; private set; }
 
-        private void ValidateActionReturnType<TActionResult>() where TActionResult : ActionResult
+        public void ValidateActionReturnType<TActionResult>() where TActionResult : ActionResult
         {
-            var castedActionResult = _actionResult as TActionResult;
+            var castedActionResult = ActionResult as TActionResult;
 
-            if (_actionResult == null)
+            if (ActionResult == null)
                 throw new ActionResultAssertionException(string.Format("Received null action result when expecting {0}.", typeof(TActionResult).Name));
 
             if (castedActionResult == null)
                 throw new ActionResultAssertionException(
                     string.Format("Expected action result to be a {0}, but instead received a {1}.",
-                                  typeof(TActionResult).Name, _actionResult.GetType().Name
+                                  typeof(TActionResult).Name, ActionResult.GetType().Name
                         )
                     );
         }
 
         public ControllerResultTest(T controller, string actionName, ActionResult actionResult)
         {
-            _controller = controller;
-            _actionName = actionName;
-            _actionResult = actionResult;
+            Controller = controller;
+            ActionName = actionName;
+            ActionResult = actionResult;
         }
     }
 }

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldGiveHttpStatus.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldGiveHttpStatus.cs
@@ -14,7 +14,7 @@ namespace TestStack.FluentMVCTesting
         {
             ValidateActionReturnType<HttpStatusCodeResult>();
 
-            var statusCodeResult = (HttpStatusCodeResult)_actionResult;
+            var statusCodeResult = (HttpStatusCodeResult)ActionResult;
 
             if (statusCodeResult.StatusCode != status)
                 throw new ActionResultAssertionException(string.Format("Expected HTTP status code to be '{0}', but instead received a '{1}'.", status, statusCodeResult.StatusCode));

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRedirectTo.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRedirectTo.cs
@@ -12,7 +12,7 @@ namespace TestStack.FluentMVCTesting
         public void ShouldRedirectTo(string url)
         {
             ValidateActionReturnType<RedirectResult>();
-            var redirectResult = (RedirectResult)_actionResult;
+            var redirectResult = (RedirectResult)ActionResult;
 
             if (redirectResult.Url != url)
                 throw new ActionResultAssertionException(string.Format("Expected redirect to URL '{0}', but instead was given a redirect to URL '{1}'.", url, redirectResult.Url));
@@ -21,7 +21,7 @@ namespace TestStack.FluentMVCTesting
         public RouteValueDictionary ShouldRedirectToRoute(string route)
         {
             ValidateActionReturnType<RedirectToRouteResult>();
-            var redirectResult = (RedirectToRouteResult)_actionResult;
+            var redirectResult = (RedirectToRouteResult)ActionResult;
 
             if (redirectResult.RouteName != route)
                 throw new ActionResultAssertionException(string.Format("Expected redirect to route '{0}', but instead was given a redirect to route '{1}'.", route, redirectResult.RouteName));
@@ -31,27 +31,27 @@ namespace TestStack.FluentMVCTesting
 
         public RouteValueDictionary ShouldRedirectTo(Func<T, Func<ActionResult>> actionRedirectedTo)
         {
-            return ShouldRedirectTo(actionRedirectedTo(_controller).Method);
+            return ShouldRedirectTo(actionRedirectedTo(Controller).Method);
         }
 
         public RouteValueDictionary ShouldRedirectTo(Func<T, Func<int, ActionResult>> actionRedirectedTo)
         {
-            return ShouldRedirectTo(actionRedirectedTo(_controller).Method);
+            return ShouldRedirectTo(actionRedirectedTo(Controller).Method);
         }
 
         public RouteValueDictionary ShouldRedirectTo<T1>(Func<T, Func<T1, ActionResult>> actionRedirectedTo)
         {
-            return ShouldRedirectTo(actionRedirectedTo(_controller).Method);
+            return ShouldRedirectTo(actionRedirectedTo(Controller).Method);
         }
 
         public RouteValueDictionary ShouldRedirectTo<T1, T2>(Func<T, Func<T1, T2, ActionResult>> actionRedirectedTo)
         {
-            return ShouldRedirectTo(actionRedirectedTo(_controller).Method);
+            return ShouldRedirectTo(actionRedirectedTo(Controller).Method);
         }
 
         public RouteValueDictionary ShouldRedirectTo<T1, T2, T3>(Func<T, Func<T1, T2, T3, ActionResult>> actionRedirectedTo)
         {
-            return ShouldRedirectTo(actionRedirectedTo(_controller).Method);
+            return ShouldRedirectTo(actionRedirectedTo(Controller).Method);
         }
 
         public RouteValueDictionary ShouldRedirectTo(Expression<Action<T>> actionRedirectedTo)
@@ -66,7 +66,7 @@ namespace TestStack.FluentMVCTesting
 
             var controllerName = new Regex(@"Controller$").Replace(typeof(T).Name, "");
             var actionName = method.Name;
-            var redirectResult = (RedirectToRouteResult)_actionResult;
+            var redirectResult = (RedirectToRouteResult)ActionResult;
 
             if (redirectResult.RouteValues.ContainsKey("Controller") && redirectResult.RouteValues["Controller"].ToString() != controllerName)
                 throw new ActionResultAssertionException(string.Format("Expected redirect to controller '{0}', but instead was given a redirect to controller '{1}'.", controllerName, redirectResult.RouteValues["Controller"]));
@@ -114,7 +114,7 @@ namespace TestStack.FluentMVCTesting
             var controllerName = new Regex(@"Controller$").Replace(typeof(TController).Name, "");
             var actionName = methodInfo.Name;
 
-            var redirectResult = (RedirectToRouteResult)_actionResult;
+            var redirectResult = (RedirectToRouteResult)ActionResult;
 
             if (redirectResult.RouteValues["Controller"] == null)
                 throw new ActionResultAssertionException(string.Format("Expected redirect to action '{0}' in '{1}' controller, but instead was given redirect to action '{2}' within the same controller.", actionName, controllerName, redirectResult.RouteValues["Action"]));

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRenderFile.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRenderFile.cs
@@ -30,7 +30,7 @@ namespace TestStack.FluentMVCTesting
         public FileResult ShouldRenderAnyFile(string contentType = null)
         {
             ValidateActionReturnType<FileResult>();
-            var fileResult = (FileResult)_actionResult;
+            var fileResult = (FileResult)ActionResult;
 
             EnsureContentTypeIsSame(fileResult.ContentType, contentType);
 
@@ -40,7 +40,7 @@ namespace TestStack.FluentMVCTesting
         public FileContentResult ShouldRenderFileContents(byte[] contents = null, string contentType = null)
         {
             ValidateActionReturnType<FileContentResult>();
-            var fileResult = (FileContentResult)_actionResult;
+            var fileResult = (FileContentResult)ActionResult;
 
             EnsureContentTypeIsSame(fileResult.ContentType, contentType);
 
@@ -58,7 +58,7 @@ namespace TestStack.FluentMVCTesting
         public FileContentResult ShouldRenderFileContents(string contents, string contentType = null, Encoding encoding = null)
         {
             ValidateActionReturnType<FileContentResult>();
-            var fileResult = (FileContentResult)_actionResult;
+            var fileResult = (FileContentResult)ActionResult;
 
             EnsureContentTypeIsSame(fileResult.ContentType, contentType);
 
@@ -86,7 +86,7 @@ namespace TestStack.FluentMVCTesting
         public FileStreamResult ShouldRenderFileStream(Stream stream = null, string contentType = null)
         {
             ValidateActionReturnType<FileStreamResult>();
-            var fileResult = (FileStreamResult)_actionResult;
+            var fileResult = (FileStreamResult)ActionResult;
 
             EnsureContentTypeIsSame(fileResult.ContentType, contentType);
 
@@ -110,7 +110,7 @@ namespace TestStack.FluentMVCTesting
         public FileStreamResult ShouldRenderFileStream(string contents, string contentType = null, Encoding encoding = null)
         {
             ValidateActionReturnType<FileStreamResult>();
-            var fileResult = (FileStreamResult)_actionResult;
+            var fileResult = (FileStreamResult)ActionResult;
 
             EnsureContentTypeIsSame(fileResult.ContentType, contentType);
 
@@ -132,7 +132,7 @@ namespace TestStack.FluentMVCTesting
         public FilePathResult ShouldRenderFilePath(string fileName = null, string contentType = null)
         {
             ValidateActionReturnType<FilePathResult>();
-            var fileResult = (FilePathResult)_actionResult;
+            var fileResult = (FilePathResult)ActionResult;
 
             EnsureContentTypeIsSame(fileResult.ContentType, contentType);
 

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRenderView.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRenderView.cs
@@ -8,14 +8,14 @@ namespace TestStack.FluentMVCTesting
         {
             ValidateActionReturnType<TViewResult>();
 
-            var viewResult = (TViewResult)_actionResult;
+            var viewResult = (TViewResult)ActionResult;
 
-            if (viewResult.ViewName != viewName && (viewName != _actionName || viewResult.ViewName != ""))
+            if (viewResult.ViewName != viewName && (viewName != ActionName || viewResult.ViewName != ""))
             {
-                throw new ActionResultAssertionException(string.Format("Expected result view to be '{0}', but instead was given '{1}'.", viewName, viewResult.ViewName == "" ? _actionName : viewResult.ViewName));
+                throw new ActionResultAssertionException(string.Format("Expected result view to be '{0}', but instead was given '{1}'.", viewName, viewResult.ViewName == "" ? ActionName : viewResult.ViewName));
             }
 
-            return new ViewResultTest(viewResult, _controller);
+            return new ViewResultTest(viewResult, Controller);
         }
 
         public ViewResultTest ShouldRenderView(string viewName)
@@ -30,12 +30,12 @@ namespace TestStack.FluentMVCTesting
 
         public ViewResultTest ShouldRenderDefaultView()
         {
-            return ShouldRenderView(_actionName);
+            return ShouldRenderView(ActionName);
         }
 
         public ViewResultTest ShouldRenderDefaultPartialView()
         {
-            return ShouldRenderPartialView(_actionName);
+            return ShouldRenderPartialView(ActionName);
         }
     }
 }

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldReturnContent.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldReturnContent.cs
@@ -8,7 +8,7 @@ namespace TestStack.FluentMVCTesting
         public ContentResult ShouldReturnContent(string content = null, string contentType = null, Encoding encoding = null)
         {
             ValidateActionReturnType<ContentResult>();
-            var contentResult = (ContentResult)_actionResult;
+            var contentResult = (ContentResult)ActionResult;
 
             if (contentType != null && contentType != contentResult.ContentType)
             {

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldReturnJson.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldReturnJson.cs
@@ -13,7 +13,7 @@ namespace TestStack.FluentMVCTesting
         public void ShouldReturnJson(Action<dynamic> assertion)
         {
             ValidateActionReturnType<JsonResult>();
-            var jsonResult = (JsonResult)_actionResult;
+            var jsonResult = (JsonResult)ActionResult;
             assertion(jsonResult.Data);
         }
     }


### PR DESCRIPTION
If I understood correctly, this solves issue #40. 

You will now be able to write custom assertion methods like this one:

``` c#
public static class ControllerResultTestExtensions
{
    public static void ShouldGiveHttpUnauthorizedResult<TController>(
        this ControllerResultTest<TController> result) where TController : Controller
    {
        result.ValidateActionReturnType<HttpUnauthorizedResult>();
        var httpUnauthorizedResult = (HttpUnauthorizedResult) result.ActionResult;
        if (httpUnauthorizedResult.StatusCode != 1337)
        {
        }
    }
}
```

(Arbitrary example.)

We will need to update the documentation (and maybe add some XML comments in the future.)
