### PR TITLE
Mvcpipeline2

### DIFF
--- a/TestStack.FluentMVCTesting.Tests/TestStack.FluentMVCTesting.Tests.csproj
+++ b/TestStack.FluentMVCTesting.Tests/TestStack.FluentMVCTesting.Tests.csproj
@@ -108,6 +108,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/TestStack.FluentMVCTesting.Tests/app.config
+++ b/TestStack.FluentMVCTesting.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/TestStack.FluentMvcTesting/ControllerExtensions.cs
+++ b/TestStack.FluentMvcTesting/ControllerExtensions.cs
@@ -21,19 +21,19 @@ namespace TestStack.FluentMVCTesting
             where T : Controller
             where TAction : ActionResult
         {
-#if NET45
-            var expression = Expression.Lambda<Func<T, object>>(Expression.Convert(actionCall.Body, typeof(object)), actionCall.Parameters);
-            var action = controller.Action(expression);
-            var result = action.Execute();
+//#if NET45
+//            var expression = Expression.Lambda<Func<T, object>>(Expression.Convert(actionCall.Body, typeof(object)), actionCall.Parameters);
+//            var action = controller.Action(expression);
+//            var result = action.Execute();
 
-            return new ControllerResultTest<T>(controller, action.ActionDescriptor.ActionName, result.ActionResult);
-#else
+//            return new ControllerResultTest<T>(controller, action.ActionDescriptor.ActionName, result.ActionResult);
+//#else
             var actionName = ((MethodCallExpression)actionCall.Body).Method.Name;
 
             var actionResult = actionCall.Compile().Invoke(controller);
 
             return new ControllerResultTest<T>(controller, actionName, actionResult);
-#endif
+//#endif
         }
 
         public static ControllerResultTest<T> WithCallTo<T, TAction>(this T controller, Expression<Func<T, Task<TAction>>> actionCall)

--- a/TestStack.FluentMvcTesting/TestStack.FluentMVCTesting.csproj
+++ b/TestStack.FluentMvcTesting/TestStack.FluentMVCTesting.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -74,6 +74,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Xania.AspNet.Simulator">
+      <HintPath>..\packages\Xania.AspNet.Simulator.1.2.11\lib\net45\Xania.AspNet.Simulator.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Packages\ExpressionStringBuilder.0.9.2\ExpressionStringBuilder.cs" />
@@ -95,6 +98,7 @@
     <Compile Include="ViewResultTest.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="TestStack.FluentMVCTesting.nuspec" />
   </ItemGroup>

--- a/TestStack.FluentMvcTesting/app.config
+++ b/TestStack.FluentMvcTesting/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/TestStack.FluentMvcTesting/packages.config
+++ b/TestStack.FluentMvcTesting/packages.config
@@ -5,4 +5,5 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="Xania.AspNet.Simulator" version="1.2.11" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Beginning of WithMvcPipelineTo functionality, like WithCallTo only simulates the whole MVC pipeline, meaning it will run things like filters, binders, etc.