### PR TITLE
(Issue #62): Updated link in Documentation section in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The library is compatible with the AAA testing methodology, although it combines
 Documentation
 -------------
 
-Please see [the documentation](http://docs.teststack.net/fluentmvctesting/) for full installation and usage instructions.
+Please see [the documentation](http://fluentmvctesting.teststack.net/) for full installation and usage instructions.
 
 
 Installation


### PR DESCRIPTION
Updated the documentation link in the "Documentation" section of the
README.md file, previously was broken.

File: README.md
Line: 13

New Link: http://fluentmvctesting.teststack.net/
(Same link as "Show me the code!" section)