### PR TITLE
Update code to use C# 6 features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ _ReSharper*
 */NhibernateProfiler*/tools
 packages
 /TestStack.FluentMVCTesting.Example/App_Data
+.vs/config/applicationhost.config
+.vs/TestStack.FluentMVCTesting/v15/sqlite3/storage.ide

--- a/Samples/TestStack.FluentMVCTesting.Sample.Tests/TestStack.FluentMVCTesting.Sample.Tests.csproj
+++ b/Samples/TestStack.FluentMVCTesting.Sample.Tests/TestStack.FluentMVCTesting.Sample.Tests.csproj
@@ -96,6 +96,9 @@
       <Name>TestStack.FluentMVCTesting.Sample</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TestStack.FluentMVCTesting.Mvc3.Tests/TestStack.FluentMVCTesting.Mvc3.Tests.csproj
+++ b/TestStack.FluentMVCTesting.Mvc3.Tests/TestStack.FluentMVCTesting.Mvc3.Tests.csproj
@@ -90,6 +90,9 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TestStack.FluentMVCTesting.Mvc4.Tests/TestStack.FluentMVCTesting.Mvc4.Tests.csproj
+++ b/TestStack.FluentMVCTesting.Mvc4.Tests/TestStack.FluentMVCTesting.Mvc4.Tests.csproj
@@ -91,5 +91,8 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/TestStack.FluentMVCTesting.Tests/AsyncControllerTests.cs
+++ b/TestStack.FluentMVCTesting.Tests/AsyncControllerTests.cs
@@ -27,6 +27,7 @@ namespace TestStack.FluentMVCTesting.Tests
                 () => _controller.WithCallTo(c => c.AsyncViewAction()).ShouldGiveHttpStatus()
             );
         }
+        
         [Test]
         public void Work_correctly_for_valid_child_action_check()
         {

--- a/TestStack.FluentMVCTesting.Tests/ControllerExtensionsTests.cs
+++ b/TestStack.FluentMVCTesting.Tests/ControllerExtensionsTests.cs
@@ -10,10 +10,7 @@ namespace TestStack.FluentMVCTesting.Tests
         private ControllerExtensionsController _controller;
 
         [SetUp]
-        public void Setup()
-        {
-            _controller = new ControllerExtensionsController();
-        }
+        public void Setup() => _controller = new ControllerExtensionsController();
 
         [Test]
         public void Give_controller_modelstate_errors()

--- a/TestStack.FluentMVCTesting.Tests/ControllerResultTestTests/ControllerResultTestTests.cs
+++ b/TestStack.FluentMVCTesting.Tests/ControllerResultTestTests/ControllerResultTestTests.cs
@@ -14,10 +14,7 @@ namespace TestStack.FluentMVCTesting.Tests
         private ControllerResultTestController _controller;
 
         [SetUp]
-        public void Setup()
-        {
-            _controller = new ControllerResultTestController();
-        }
+        public void Setup() => _controller = new ControllerResultTestController();
 
         #region General Tests
         // Expected action return types for the different types of assertions

--- a/TestStack.FluentMVCTesting.Tests/ControllerResultTestTests/ShouldReturnContentTests.cs
+++ b/TestStack.FluentMVCTesting.Tests/ControllerResultTestTests/ShouldReturnContentTests.cs
@@ -79,7 +79,7 @@ namespace TestStack.FluentMVCTesting.Tests
         {
             var exception = Assert.Throws<ActionResultAssertionException>(() => _controller.WithCallTo(c => c.ContentWithoutEncodingSpecified()).ShouldReturnContent(encoding: ControllerResultTestController.TextualContentEncoding));
 
-            Assert.That(exception.Message, Is.EqualTo(string.Format("Expected encoding to be equal to {0}, but instead was null.", ControllerResultTestController.TextualContentEncoding.EncodingName)));
+            Assert.That(exception.Message, Is.EqualTo($"Expected encoding to be equal to {ControllerResultTestController.TextualContentEncoding.EncodingName}, but instead was null."));
         }
 
         [Test]

--- a/TestStack.FluentMVCTesting.Tests/TestStack.FluentMVCTesting.Tests.csproj
+++ b/TestStack.FluentMVCTesting.Tests/TestStack.FluentMVCTesting.Tests.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -108,7 +109,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/TestStack.FluentMVCTesting.Tests/packages.config
+++ b/TestStack.FluentMVCTesting.Tests/packages.config
@@ -6,4 +6,5 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="NSubstitute" version="1.7.2.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
 </packages>

--- a/TestStack.FluentMvcTesting/ControllerExtensions.cs
+++ b/TestStack.FluentMvcTesting/ControllerExtensions.cs
@@ -7,7 +7,6 @@ namespace TestStack.FluentMVCTesting
 {
     public static class ControllerExtensions
     {
-
         public static T WithModelErrors<T>(this T controller) where T : Controller
         {
             controller.ModelState.AddModelError("Key", "Value");
@@ -43,7 +42,7 @@ namespace TestStack.FluentMVCTesting
             var action = ((MethodCallExpression)actionCall.Body).Method;
 
             if (!action.IsDefined(typeof(ChildActionOnlyAttribute), false))
-                throw new InvalidControllerActionException(string.Format("Expected action {0} of controller {1} to be a child action, but it didn't have the ChildActionOnly attribute.", action.Name, controller.GetType().Name));
+                throw new InvalidControllerActionException($"Expected action {action.Name} of controller {controller.GetType().Name} to be a child action, but it didn't have the ChildActionOnly attribute.");
 
             return controller.WithCallTo(actionCall);
         }
@@ -55,7 +54,7 @@ namespace TestStack.FluentMVCTesting
             var action = ((MethodCallExpression)actionCall.Body).Method;
 
             if (!action.IsDefined(typeof(ChildActionOnlyAttribute), false))
-                throw new InvalidControllerActionException(string.Format("Expected action {0} of controller {1} to be a child action, but it didn't have the ChildActionOnly attribute.", action.Name, controller.GetType().Name));
+                throw new InvalidControllerActionException($"Expected action {action.Name} of controller {controller.GetType().Name} to be a child action, but it didn't have the ChildActionOnly attribute.");
 
             return controller.WithCallTo(actionCall);
         }
@@ -66,22 +65,17 @@ namespace TestStack.FluentMVCTesting
 
             if (actual == null)
             {
-                throw new TempDataAssertionException(string.Format(
-                    "Expected TempData to have a non-null value with key '{0}', but none found.", key));
+                throw new TempDataAssertionException($"Expected TempData to have a non-null value with key '{key}', but none found.");
             }
 
             if (value != null && actual.GetType() != value.GetType())
             {
-                throw new TempDataAssertionException(string.Format(
-                    "Expected value to be of type {0}, but instead was {1}.",
-                    value.GetType().FullName,
-                    actual.GetType().FullName));
+                throw new TempDataAssertionException($"Expected value to be of type {value.GetType().FullName}, but instead was {actual.GetType().FullName}.");
             }
 
             if (value != null && !value.Equals(actual))
             {
-                throw new TempDataAssertionException(string.Format(
-                    "Expected value for key '{0}' to be '{1}', but instead found '{2}'", key, value, actual));
+                throw new TempDataAssertionException($"Expected value for key '{key}' to be '{value}', but instead found '{actual}'");
             }
 
             return new TempDataResultTest(controller);
@@ -93,8 +87,7 @@ namespace TestStack.FluentMVCTesting
 
             if (actual == null)
             {
-                throw new TempDataAssertionException(string.Format(
-                    "Expected TempData to have a non-null value with key '{0}', but none found.", key));
+                throw new TempDataAssertionException($"Expected TempData to have a non-null value with key '{key}', but none found.");
             }
 
             if (!predicate((TValue)actual))
@@ -111,8 +104,7 @@ namespace TestStack.FluentMVCTesting
 
             if (actual != null)
             {
-                throw new TempDataAssertionException(string.Format(
-                    "Expected TempData to have no value with key '{0}', but found one.", key));
+                throw new TempDataAssertionException($"Expected TempData to have no value with key '{key}', but found one.");
             }
 
             return new TempDataResultTest(controller);

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ControllerResultTest.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ControllerResultTest.cs
@@ -4,23 +4,19 @@ namespace TestStack.FluentMVCTesting
 {
     public partial class ControllerResultTest<T> where T : Controller
     {
-        public T Controller { get; private set; }
-        public string ActionName { get; private set; }
-        public ActionResult ActionResult { get; private set; }
+        public T Controller { get; }
+        public string ActionName { get; }
+        public ActionResult ActionResult { get; }
 
         public void ValidateActionReturnType<TActionResult>() where TActionResult : ActionResult
         {
             var castedActionResult = ActionResult as TActionResult;
 
             if (ActionResult == null)
-                throw new ActionResultAssertionException(string.Format("Received null action result when expecting {0}.", typeof(TActionResult).Name));
+                throw new ActionResultAssertionException($"Received null action result when expecting {typeof(TActionResult).Name}.");
 
             if (castedActionResult == null)
-                throw new ActionResultAssertionException(
-                    string.Format("Expected action result to be a {0}, but instead received a {1}.",
-                                  typeof(TActionResult).Name, ActionResult.GetType().Name
-                        )
-                    );
+                throw new ActionResultAssertionException($"Expected action result to be a {typeof(TActionResult).Name}, but instead received a {ActionResult.GetType().Name}.");
         }
 
         public ControllerResultTest(T controller, string actionName, ActionResult actionResult)

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldGiveHttpStatus.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldGiveHttpStatus.cs
@@ -8,7 +8,7 @@ namespace TestStack.FluentMVCTesting
         public HttpStatusCodeResult ShouldGiveHttpStatus()
         {
             ValidateActionReturnType<HttpStatusCodeResult>();
-            return (HttpStatusCodeResult) ActionResult;
+            return (HttpStatusCodeResult)ActionResult;
         }
 
         public HttpStatusCodeResult ShouldGiveHttpStatus(int status)
@@ -18,8 +18,8 @@ namespace TestStack.FluentMVCTesting
             var statusCodeResult = (HttpStatusCodeResult)ActionResult;
 
             if (statusCodeResult.StatusCode != status)
-                throw new ActionResultAssertionException(string.Format("Expected HTTP status code to be '{0}', but instead received a '{1}'.", status, statusCodeResult.StatusCode));
-            return (HttpStatusCodeResult) ActionResult;
+                throw new ActionResultAssertionException($"Expected HTTP status code to be '{status}', but instead received a '{statusCodeResult.StatusCode}'.");
+            return (HttpStatusCodeResult)ActionResult;
         }
 
         public HttpStatusCodeResult ShouldGiveHttpStatus(HttpStatusCode status)

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRedirectTo.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRedirectTo.cs
@@ -15,7 +15,7 @@ namespace TestStack.FluentMVCTesting
             var redirectResult = (RedirectResult)ActionResult;
 
             if (redirectResult.Url != url)
-                throw new ActionResultAssertionException(string.Format("Expected redirect to URL '{0}', but instead was given a redirect to URL '{1}'.", url, redirectResult.Url));
+                throw new ActionResultAssertionException($"Expected redirect to URL '{url}', but instead was given a redirect to URL '{redirectResult.Url}'.");
         }
 
         public RouteValueDictionary ShouldRedirectToRoute(string route)
@@ -24,35 +24,25 @@ namespace TestStack.FluentMVCTesting
             var redirectResult = (RedirectToRouteResult)ActionResult;
 
             if (redirectResult.RouteName != route)
-                throw new ActionResultAssertionException(string.Format("Expected redirect to route '{0}', but instead was given a redirect to route '{1}'.", route, redirectResult.RouteName));
+                throw new ActionResultAssertionException($"Expected redirect to route '{route}', but instead was given a redirect to route '{redirectResult.RouteName}'.");
 
             return redirectResult.RouteValues;
         }
 
-        public RouteValueDictionary ShouldRedirectTo(Func<T, Func<ActionResult>> actionRedirectedTo)
-        {
-            return ShouldRedirectTo(actionRedirectedTo(Controller).Method);
-        }
+        public RouteValueDictionary ShouldRedirectTo(Func<T, Func<ActionResult>> actionRedirectedTo) => 
+            ShouldRedirectTo(actionRedirectedTo(Controller).Method); 
 
-        public RouteValueDictionary ShouldRedirectTo(Func<T, Func<int, ActionResult>> actionRedirectedTo)
-        {
-            return ShouldRedirectTo(actionRedirectedTo(Controller).Method);
-        }
+        public RouteValueDictionary ShouldRedirectTo(Func<T, Func<int, ActionResult>> actionRedirectedTo) => 
+            ShouldRedirectTo(actionRedirectedTo(Controller).Method);
 
-        public RouteValueDictionary ShouldRedirectTo<T1>(Func<T, Func<T1, ActionResult>> actionRedirectedTo)
-        {
-            return ShouldRedirectTo(actionRedirectedTo(Controller).Method);
-        }
+        public RouteValueDictionary ShouldRedirectTo<T1>(Func<T, Func<T1, ActionResult>> actionRedirectedTo) => 
+            ShouldRedirectTo(actionRedirectedTo(Controller).Method);
 
-        public RouteValueDictionary ShouldRedirectTo<T1, T2>(Func<T, Func<T1, T2, ActionResult>> actionRedirectedTo)
-        {
-            return ShouldRedirectTo(actionRedirectedTo(Controller).Method);
-        }
+        public RouteValueDictionary ShouldRedirectTo<T1, T2>(Func<T, Func<T1, T2, ActionResult>> actionRedirectedTo) => 
+            ShouldRedirectTo(actionRedirectedTo(Controller).Method);
 
-        public RouteValueDictionary ShouldRedirectTo<T1, T2, T3>(Func<T, Func<T1, T2, T3, ActionResult>> actionRedirectedTo)
-        {
-            return ShouldRedirectTo(actionRedirectedTo(Controller).Method);
-        }
+        public RouteValueDictionary ShouldRedirectTo<T1, T2, T3>(Func<T, Func<T1, T2, T3, ActionResult>> actionRedirectedTo) => 
+            ShouldRedirectTo(actionRedirectedTo(Controller).Method);
 
         public RouteValueDictionary ShouldRedirectTo(Expression<Action<T>> actionRedirectedTo)
         {
@@ -69,13 +59,13 @@ namespace TestStack.FluentMVCTesting
             var redirectResult = (RedirectToRouteResult)ActionResult;
 
             if (redirectResult.RouteValues.ContainsKey("Controller") && redirectResult.RouteValues["Controller"].ToString() != controllerName)
-                throw new ActionResultAssertionException(string.Format("Expected redirect to controller '{0}', but instead was given a redirect to controller '{1}'.", controllerName, redirectResult.RouteValues["Controller"]));
+                throw new ActionResultAssertionException($"Expected redirect to controller '{controllerName}', but instead was given a redirect to controller '{redirectResult.RouteValues["Controller"]}'.");
 
             if (!redirectResult.RouteValues.ContainsKey("Action"))
-                throw new ActionResultAssertionException(string.Format("Expected redirect to action '{0}', but instead was given a redirect without an action.", actionName));
+                throw new ActionResultAssertionException($"Expected redirect to action '{actionName}', but instead was given a redirect without an action.");
 
             if (redirectResult.RouteValues["Action"].ToString() != actionName)
-                throw new ActionResultAssertionException(string.Format("Expected redirect to action '{0}', but instead was given a redirect to action '{1}'.", actionName, redirectResult.RouteValues["Action"]));
+                throw new ActionResultAssertionException($"Expected redirect to action '{actionName}', but instead was given a redirect to action '{redirectResult.RouteValues["Action"]}'.");
 
             if (expectedValues == null)
                 return redirectResult.RouteValues;
@@ -85,16 +75,11 @@ namespace TestStack.FluentMVCTesting
                 object actualValue;
                 if (!redirectResult.RouteValues.TryGetValue(expectedRouteValue.Key, out actualValue))
                 {
-                    throw new ActionResultAssertionException(string.Format("Expected redirect to have parameter '{0}', but it did not.", expectedRouteValue.Key));
+                    throw new ActionResultAssertionException($"Expected redirect to have parameter '{expectedRouteValue.Key}', but it did not.");
                 }
                 if (actualValue.ToString() != expectedRouteValue.Value.ToString())
                 {
-                    throw new ActionResultAssertionException(
-                        string.Format("Expected parameter '{0}' to have value '{1}', but instead was given value '{2}'."
-                                      , expectedRouteValue.Key
-                                      , expectedRouteValue.Value
-                                      , actualValue
-                            ));
+                    throw new ActionResultAssertionException($"Expected parameter '{expectedRouteValue.Key}' to have value '{expectedRouteValue.Value}', but instead was given value '{actualValue}'.");
                 }
             }
 
@@ -122,15 +107,13 @@ namespace TestStack.FluentMVCTesting
             }
 
             if (redirectResult.RouteValues["Controller"] == null)
-            {
-                throw new ActionResultAssertionException(string.Format("Expected redirect to action '{0}' in '{1}' controller, but instead was given redirect to action '{2}' within the same controller.", actionName, controllerName, redirectResult.RouteValues["Action"]));
-            }
+                throw new ActionResultAssertionException($"Expected redirect to action '{actionName}' in '{controllerName}' controller, but instead was given redirect to action '{redirectResult.RouteValues["Action"]}' within the same controller.");
 
             if (redirectResult.RouteValues["Controller"].ToString() != controllerName)
-                throw new ActionResultAssertionException(string.Format("Expected redirect to controller '{0}', but instead was given a redirect to controller '{1}'.", controllerName, redirectResult.RouteValues["Controller"]));
+                throw new ActionResultAssertionException($"Expected redirect to controller '{controllerName}', but instead was given a redirect to controller '{redirectResult.RouteValues["Controller"]}'.");
 
             if (redirectResult.RouteValues["Action"].ToString() != actionName)
-                throw new ActionResultAssertionException(string.Format("Expected redirect to action '{0}', but instead was given a redirect to action '{1}'.", actionName, redirectResult.RouteValues["Action"]));
+                throw new ActionResultAssertionException($"Expected redirect to action '{actionName}', but instead was given a redirect to action '{redirectResult.RouteValues["Action"]}'.");
 
             return redirectResult.RouteValues;
         }

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRenderFile.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRenderFile.cs
@@ -11,10 +11,7 @@ namespace TestStack.FluentMVCTesting
         {
             if (expected == null) return;
             if (actual != expected)
-            {
-                throw new ActionResultAssertionException(string.Format(
-                    "Expected file to be of content type '{0}', but instead was given '{1}'.", expected, actual));
-            }
+                throw new ActionResultAssertionException($"Expected file to be of content type '{expected}', but instead was given '{actual}'.");
         }
 
         private static byte[] ConvertStreamToArray(Stream stream)
@@ -45,12 +42,7 @@ namespace TestStack.FluentMVCTesting
             EnsureContentTypeIsSame(fileResult.ContentType, contentType);
 
             if (contents != null && !fileResult.FileContents.SequenceEqual(contents))
-            {
-                throw new ActionResultAssertionException(string.Format(
-                    "Expected file contents to be equal to [{0}], but instead was given [{1}].",
-                    string.Join(", ", contents),
-                    string.Join(", ", fileResult.FileContents)));
-            }
+                throw new ActionResultAssertionException($"Expected file contents to be equal to [{string.Join(", ", contents)}], but instead was given [{string.Join(", ", fileResult.FileContents)}].");
 
             return fileResult;
         }
@@ -67,12 +59,7 @@ namespace TestStack.FluentMVCTesting
 
             var reconstitutedText = encoding.GetString(fileResult.FileContents);
             if (contents != reconstitutedText)
-            {
-                throw new ActionResultAssertionException(string.Format(
-                    "Expected file contents to be '{0}', but instead was '{1}'.",
-                    contents,
-                    reconstitutedText));
-            }
+                throw new ActionResultAssertionException($"Expected file contents to be '{contents}', but instead was '{reconstitutedText}'.");
 
             return fileResult;
         }
@@ -97,10 +84,7 @@ namespace TestStack.FluentMVCTesting
 
                 if (!expected.SequenceEqual(actual))
                 {
-                    throw new ActionResultAssertionException(string.Format(
-                        "Expected file contents to be equal to [{0}], but instead was given [{1}].",
-                        string.Join(", ", expected),
-                        string.Join(", ", actual)));
+                    throw new ActionResultAssertionException($"Expected file contents to be equal to [{string.Join(", ", expected)}], but instead was given [{string.Join(", ", actual)}].");
                 }
             }
 
@@ -119,12 +103,7 @@ namespace TestStack.FluentMVCTesting
 
             var reconstitutedText = encoding.GetString(ConvertStreamToArray(fileResult.FileStream));
             if (contents != reconstitutedText)
-            {
-                throw new ActionResultAssertionException(string.Format(
-                    "Expected file contents to be '{0}', but instead was '{1}'.",
-                    contents,
-                    reconstitutedText));
-            }
+                throw new ActionResultAssertionException($"Expected file contents to be '{contents}', but instead was '{reconstitutedText}'.");
 
             return fileResult;
         }
@@ -137,12 +116,7 @@ namespace TestStack.FluentMVCTesting
             EnsureContentTypeIsSame(fileResult.ContentType, contentType);
 
             if (fileName != null && fileName != fileResult.FileName)
-            {
-                throw new ActionResultAssertionException(string.Format(
-                    "Expected file name to be '{0}', but instead was given '{1}'.",
-                    fileName,
-                    fileResult.FileName));
-            }
+                throw new ActionResultAssertionException($"Expected file name to be '{fileName}', but instead was given '{fileResult.FileName}'.");
 
             return fileResult;
         }

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRenderView.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldRenderView.cs
@@ -12,30 +12,19 @@ namespace TestStack.FluentMVCTesting
 
             if (viewResult.ViewName != viewName && (viewName != ActionName || viewResult.ViewName != ""))
             {
-                throw new ActionResultAssertionException(string.Format("Expected result view to be '{0}', but instead was given '{1}'.", viewName, viewResult.ViewName == "" ? ActionName : viewResult.ViewName));
+                var actualViewName = viewResult.ViewName == "" ? ActionName : viewResult.ViewName;
+                throw new ActionResultAssertionException($"Expected result view to be '{viewName}', but instead was given '{actualViewName}'.");
             }
-
+                
             return new ViewResultTest(viewResult, Controller);
         }
 
-        public ViewResultTest ShouldRenderView(string viewName)
-        {
-            return ShouldRenderViewResult<ViewResult>(viewName);
-        }
+        public ViewResultTest ShouldRenderView(string viewName) => ShouldRenderViewResult<ViewResult>(viewName);
 
-        public ViewResultTest ShouldRenderPartialView(string viewName)
-        {
-            return ShouldRenderViewResult<PartialViewResult>(viewName);
-        }
+        public ViewResultTest ShouldRenderPartialView(string viewName) => ShouldRenderViewResult<PartialViewResult>(viewName);
 
-        public ViewResultTest ShouldRenderDefaultView()
-        {
-            return ShouldRenderView(ActionName);
-        }
+        public ViewResultTest ShouldRenderDefaultView() => ShouldRenderView(ActionName);
 
-        public ViewResultTest ShouldRenderDefaultPartialView()
-        {
-            return ShouldRenderPartialView(ActionName);
-        }
+        public ViewResultTest ShouldRenderDefaultPartialView() => ShouldRenderPartialView(ActionName);
     }
 }

--- a/TestStack.FluentMvcTesting/ControllerResultTest/ShouldReturnContent.cs
+++ b/TestStack.FluentMvcTesting/ControllerResultTest/ShouldReturnContent.cs
@@ -11,27 +11,15 @@ namespace TestStack.FluentMVCTesting
             var contentResult = (ContentResult)ActionResult;
 
             if (contentType != null && contentType != contentResult.ContentType)
-            {
-                throw new ActionResultAssertionException(string.Format(
-                    "Expected content type to be '{0}', but instead was '{1}'.",
-                    contentType,
-                    contentResult.ContentType));
-            }
+                throw new ActionResultAssertionException($"Expected content type to be '{contentType}', but instead was '{contentResult.ContentType}'.");
 
             if (content != null && content != contentResult.Content)
-            {
-                throw new ActionResultAssertionException(string.Format(
-                    "Expected content to be '{0}', but instead was '{1}'.",
-                    content,
-                    contentResult.Content));
-            }
+                throw new ActionResultAssertionException($"Expected content to be '{content}', but instead was '{contentResult.Content}'.");
 
             if (encoding != null && encoding != contentResult.ContentEncoding)
             {
-                throw new ActionResultAssertionException(string.Format(
-                    "Expected encoding to be equal to {0}, but instead was {1}.",
-                    encoding.EncodingName,
-                    contentResult.ContentEncoding != null ? contentResult.ContentEncoding.EncodingName : "null"));
+                var actualEncoding = contentResult.ContentEncoding?.EncodingName ?? "null";
+                throw new ActionResultAssertionException($"Expected encoding to be equal to {encoding.EncodingName}, but instead was {actualEncoding}.");
             }
 
             return contentResult;

--- a/TestStack.FluentMvcTesting/ModelErrorTest.cs
+++ b/TestStack.FluentMvcTesting/ModelErrorTest.cs
@@ -22,6 +22,7 @@ namespace TestStack.FluentMVCTesting
         private readonly IModelTest<TModel> _modelTest;
         private readonly string _errorKey;
         private readonly List<string> _errors;
+        private string InflectedErrors => string.Join(", ", _errors);
 
         public ModelErrorTest(IModelTest<TModel> modelTest, string errorKey, IEnumerable<ModelError> errors)
         {
@@ -33,52 +34,35 @@ namespace TestStack.FluentMVCTesting
         public IModelTest<TModel> ThatEquals(string errorMessage)
         {
             if (!_errors.Any(e => e == errorMessage))
-            {
-                throw new ModelErrorAssertionException(string.Format("Expected error message for key '{0}' to be '{1}', but instead found '{2}'.", _errorKey, errorMessage, string.Join(", ", _errors)));
-            }
+                throw new ModelErrorAssertionException($"Expected error message for key '{_errorKey}' to be '{errorMessage}', but instead found '{InflectedErrors}'.");
             return _modelTest;
         }
 
         public IModelTest<TModel> BeginningWith(string beginMessage)
         {
             if (!_errors.Any(e => e.StartsWith(beginMessage)))
-            {
-                throw new ModelErrorAssertionException(string.Format("Expected error message for key '{0}' to start with '{1}', but instead found '{2}'.", _errorKey, beginMessage, string.Join(", ", _errors)));
-            }
+                throw new ModelErrorAssertionException($"Expected error message for key '{_errorKey}' to start with '{beginMessage}', but instead found '{InflectedErrors}'.");
             return _modelTest;
         }
 
         public IModelTest<TModel> EndingWith(string endMessage)
         {
             if (!_errors.Any(e => e.EndsWith(endMessage)))
-            {
-                throw new ModelErrorAssertionException(string.Format("Expected error message for key '{0}' to end with '{1}', but instead found '{2}'.", _errorKey, endMessage, string.Join(", ", _errors)));
-            }
+                throw new ModelErrorAssertionException($"Expected error message for key '{_errorKey}' to end with '{endMessage}', but instead found '{InflectedErrors}'.");
             return _modelTest;
         }
 
         public IModelTest<TModel> Containing(string containsMessage)
         {
             if (!_errors.Any(e => e.Contains(containsMessage)))
-            {
-                throw new ModelErrorAssertionException(string.Format("Expected error message for key '{0}' to contain '{1}', but instead found '{2}'.", _errorKey, containsMessage, string.Join(", ", _errors)));
-            }
+                throw new ModelErrorAssertionException($"Expected error message for key '{_errorKey}' to contain '{containsMessage}', but instead found '{InflectedErrors}'.");
             return _modelTest;
         }
 
-        public IModelErrorTest<TModel> AndModelErrorFor<TAttribute>(Expression<Func<TModel, TAttribute>> memberWithError)
-        {
-            return _modelTest.AndModelErrorFor(memberWithError);
-        }
+        public IModelErrorTest<TModel> AndModelErrorFor<TAttribute>(Expression<Func<TModel, TAttribute>> memberWithError) => _modelTest.AndModelErrorFor(memberWithError);
 
-        public IModelErrorTest<TModel> AndModelError(string errorKey)
-        {
-            return _modelTest.AndModelError(errorKey);
-        }
+        public IModelErrorTest<TModel> AndModelError(string errorKey) => _modelTest.AndModelError(errorKey);
 
-        public IModelTest<TModel> AndNoModelErrorFor<TAttribute>(Expression<Func<TModel, TAttribute>> memberWithNoError)
-        {
-            return _modelTest.AndNoModelErrorFor(memberWithNoError);
-        }
+        public IModelTest<TModel> AndNoModelErrorFor<TAttribute>(Expression<Func<TModel, TAttribute>> memberWithNoError) => _modelTest.AndNoModelErrorFor(memberWithNoError);
     }
 }

--- a/TestStack.FluentMvcTesting/ModelTest.cs
+++ b/TestStack.FluentMvcTesting/ModelTest.cs
@@ -15,6 +15,7 @@ namespace TestStack.FluentMVCTesting
     public class ModelTest<TModel> : IModelTest<TModel>
     {
         private readonly Controller _controller;
+        private string ControllerName => _controller.GetType().Name;
 
         public ModelTest(Controller controller)
         {
@@ -25,7 +26,7 @@ namespace TestStack.FluentMVCTesting
         {
             var member = ((MemberExpression)memberWithError.Body).Member.Name;
             if (!_controller.ModelState.ContainsKey(member) || _controller.ModelState[member].Errors.Count == 0)
-                throw new ViewResultModelAssertionException(string.Format("Expected controller '{0}' to have a model error for member '{1}', but none found.", _controller.GetType().Name, member));
+                throw new ViewResultModelAssertionException($"Expected controller '{ControllerName}' to have a model error for member '{member}', but none found.");
             return new ModelErrorTest<TModel>(this, member, _controller.ModelState[member].Errors);
         }
 
@@ -33,21 +34,21 @@ namespace TestStack.FluentMVCTesting
         {
             var member = ((MemberExpression)memberWithNoError.Body).Member.Name;
             if (_controller.ModelState.ContainsKey(member))
-                throw new ViewResultModelAssertionException(string.Format("Expected controller '{0}' to have no model errors for member '{1}', but found some.", _controller.GetType().Name, member));
+                throw new ViewResultModelAssertionException($"Expected controller '{ControllerName}' to have no model errors for member '{member}', but found some.");
             return this;
         }
 
         public IModelErrorTest<TModel> AndModelError(string errorKey)
         {
             if (!_controller.ModelState.ContainsKey(errorKey) || _controller.ModelState[errorKey].Errors.Count == 0)
-                throw new ViewResultModelAssertionException(string.Format("Expected controller '{0}' to have a model error against key '{1}', but none found.", _controller.GetType().Name, errorKey));
+                throw new ViewResultModelAssertionException($"Expected controller '{ControllerName}' to have a model error against key '{errorKey}', but none found.");
             return new ModelErrorTest<TModel>(this, errorKey, _controller.ModelState[errorKey].Errors);
         }
 
         public void AndNoModelErrors()
         {
             if (!_controller.ModelState.IsValid)
-                throw new ViewResultModelAssertionException(string.Format("Expected controller '{0}' to have no model errors, but it had some.", _controller.GetType().Name));
+                throw new ViewResultModelAssertionException($"Expected controller '{ControllerName}' to have no model errors, but it had some.");
         }
     }
 }

--- a/TestStack.FluentMvcTesting/RouteValueDictionaryExtension.cs
+++ b/TestStack.FluentMvcTesting/RouteValueDictionaryExtension.cs
@@ -7,9 +7,7 @@ namespace TestStack.FluentMVCTesting
         public static RouteValueDictionary WithRouteValue(this RouteValueDictionary dict, string key)
         {
             if (!dict.ContainsKey(key))
-            {
-                throw new MissingRouteValueException(string.Format("No value {0} in the route dictionary", key));
-            }
+                throw new MissingRouteValueException($"No value {key} in the route dictionary");
 
             return dict;
         }
@@ -21,14 +19,10 @@ namespace TestStack.FluentMVCTesting
             var actualValue = dict[key];
 
             if (!(actualValue is T))
-            {
-                throw new ValueTypeMismatchException(string.Format("Invalid type of Value with key {0} \r\n expected {1} \r\n but got {2}", key, value.GetType(), actualValue.GetType()));
-            }
+                throw new ValueTypeMismatchException($"Invalid type of Value with key {key} \r\n expected {value.GetType()} \r\n but got {actualValue.GetType()}");
 
             if (!Equals(actualValue, value))
-            {
-                throw new InvalidRouteValueException(string.Format("Invalid value for key {0} \r\n expected {1} \r\n but got {2} in the route dictionary",key ,value, actualValue));
-            }
+                throw new InvalidRouteValueException($"Invalid value for key {key} \r\n expected {value} \r\n but got {actualValue} in the route dictionary");
 
             return dict;
         }

--- a/TestStack.FluentMvcTesting/TestStack.FluentMVCTesting.csproj
+++ b/TestStack.FluentMvcTesting/TestStack.FluentMVCTesting.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+	<LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/TestStack.FluentMvcTesting/ViewResultTest.cs
+++ b/TestStack.FluentMvcTesting/ViewResultTest.cs
@@ -25,7 +25,7 @@ namespace TestStack.FluentMVCTesting
 
             var castedModel = _viewResult.Model as TModel;
             if (castedModel == null)
-                throw new ViewResultModelAssertionException(string.Format("Expected view model to be of type '{0}', but it is actually of type '{1}'.", typeof(TModel).Name, _viewResult.Model.GetType().Name));
+                throw new ViewResultModelAssertionException($"Expected view model to be of type '{typeof(TModel).Name}', but it is actually of type '{_viewResult.Model.GetType().Name}'.");
 
             return new ModelTest<TModel>(_controller);
         }
@@ -52,10 +52,7 @@ namespace TestStack.FluentMVCTesting
             var compiledPredicate = predicate.Compile();
 
             if (!compiledPredicate(model))
-                throw new ViewResultModelAssertionException(string.Format(
-                    "Expected view model {0} to pass the given condition ({1}), but it failed.",
-                    modelLex, 
-                    predicateLex));
+                throw new ViewResultModelAssertionException($"Expected view model {modelLex} to pass the given condition ({predicateLex}), but it failed.");
 
             return test;
         }


### PR DESCRIPTION
Very similar to https://github.com/TestStack/TestStack.FluentMVCTesting/pull/44/ from AlexArchive. 
Haven't seen null propogation and string interpolation change since the VS2015 Preview late 2014. 
String Interpolation is confirmed to use the following syntax: $"Person Name: {person.Name}" (assuming person is an object with the property Name).
Included NUnit Test Adapter 2.1.1 to see the tests in VS Test Explorer.